### PR TITLE
Move Cloudflare analytics script to _app.tsx

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from "next/app";
+import Script from "next/script";
 import Layout from "../components/library/Layout";
 import { CSSReset, GlobalStyles } from "../styles/globals";
 
@@ -9,6 +10,10 @@ function App({ Component, pageProps }: AppProps) {
       <GlobalStyles />
       <Layout>
         <Component {...pageProps} />
+        <Script
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "659601c3710f4a01aacef8ae1f39132a"}'
+        />
       </Layout>
     </>
   );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -71,7 +71,6 @@ class PeteMillyDoc extends Document {
         <body>
           <Main />
           <NextScript />
-          {/* Cloudflare Web Analytics */}
         </body>
       </Html>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -72,10 +72,6 @@ class PeteMillyDoc extends Document {
           <Main />
           <NextScript />
           {/* Cloudflare Web Analytics */}
-          <Script
-            src="https://static.cloudflareinsights.com/beacon.min.js"
-            data-cf-beacon='{"token": "659601c3710f4a01aacef8ae1f39132a"}'
-          />
         </body>
       </Html>
     );

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,6 @@ import Document, {
   Main,
   NextScript,
 } from "next/document";
-import Script from "next/script";
 import { ServerStyleSheet } from "styled-components";
 
 class PeteMillyDoc extends Document {


### PR DESCRIPTION
The `Script` I added following instructions on [Cloudflare docs](https://developers.cloudflare.com/analytics/web-analytics/getting-started/) and [Next.js docs](https://nextjs.org/docs/basic-features/script) doesn't seem to load.

[This Stack Overflow thread suggests placing the script in `_app.tsx`](https://stackoverflow.com/questions/68058814/next-11-and-adding-script-tags-not-working-no-scripts-are-rendered), so I'll give that a shot.